### PR TITLE
Add `ProcessChunkStream`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ repository = "https://github.com/lpenz/tokio-process-stream"
 [dependencies]
 anyhow = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "process"] }
-tokio-stream = { version = "0", features = ["io-util"] }
-pin-project-lite = "0"
+tokio-stream = { version = "0.1.8", features = ["io-util"] }
+tokio-util = { version = "0.6.9", features = ["io"] }
+pin-project-lite = "0.2.8"
+bytes = "1"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Having a stream interface to processes is useful when we have multiple sources o
 we want to merge and start processing from a single entry point.
 
 This crate provides a [`core::stream::Stream`] wrapper for [`tokio::process::Child`]. The
-main struct is [`ProcessStream`], which implements the trait, yielding one [`Item`] enum at
+main struct is [`ProcessLineStream`], which implements the trait, yielding one [`Item`] enum at
 a time, each containing one line from either stdout ([`Item::Stdout`]) or stderr
 ([`Item::Stderr`]) of the underlying process until it exits. At this point, the stream
 yields a single [`Item::Done`] and finishes.
@@ -20,7 +20,7 @@ yields a single [`Item::Done`] and finishes.
 Example usage:
 
 ```rust
-use tokio_process_stream::ProcessStream;
+use tokio_process_stream::ProcessLineStream;
 use tokio::process::Command;
 use tokio_stream::StreamExt;
 use std::error::Error;
@@ -31,8 +31,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     sleep_cmd.args(&["1"]);
     let ls_cmd = Command::new("ls");
 
-    let sleep_procstream = ProcessStream::try_from(sleep_cmd)?;
-    let ls_procstream = ProcessStream::try_from(ls_cmd)?;
+    let sleep_procstream = ProcessLineStream::try_from(sleep_cmd)?;
+    let ls_procstream = ProcessLineStream::try_from(ls_cmd)?;
     let mut procstream = sleep_procstream.merge(ls_procstream);
 
     while let Some(item) = procstream.next().await {
@@ -43,13 +43,31 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 ```
 
+## Streaming chunks
+It is also possible to stream `Item<Bytes>` chunks with [`ProcessChunkStream`].
+
+```rust
+use tokio_process_stream::{Item, ProcessChunkStream};
+use tokio::process::Command;
+use tokio_stream::StreamExt;
+
+let mut procstream: ProcessChunkStream = Command::new("/bin/sh")
+    .arg("-c")
+    .arg(r#"printf "1/2"; sleep 0.1; printf "\r2/2 done\n""#)
+    .try_into()?;
+
+while let Some(item) = procstream.next().await {
+    println!("{:?}", item);
+}
+```
+
 [`tokio::process`]: https://docs.rs/tokio/latest/tokio/process
 [`tokio::stream`]: https://docs.rs/futures-core/latest/futures_core/stream
 [`core::stream::Stream`]: https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html
 [`tokio::process::Child`]: https://docs.rs/tokio/latest/tokio/process/struct.Child.html
-[`ProcessStream`]: https://docs.rs/tokio-process-stream/latest/tokio_process_stream/struct.ProcessStream.html
+[`ProcessLineStream`]: https://docs.rs/tokio-process-stream/latest/tokio_process_stream/struct.ProcessLineStream.html
+[`ProcessChunkStream`]: https://docs.rs/tokio-process-stream/latest/tokio_process_stream/struct.ProcessChunkStream.html
 [`Item`]: https://docs.rs/tokio-process-stream/latest/tokio_process_stream/enum.Item.html
 [`Item::Stdout`]: https://docs.rs/tokio-process-stream/latest/tokio_process_stream/enum.Item.html#variant.Stdout
 [`Item::Stderr`]: https://docs.rs/tokio-process-stream/latest/tokio_process_stream/enum.Item.html#variant.Stderr
 [`Item::Done`]: https://docs.rs/tokio-process-stream/latest/tokio_process_stream/enum.Item.html#variant.Done
-


### PR DESCRIPTION
* Add `ProcessChunkStream` for streaming chunks instead of lines.
* Rework `ProcessStream` to generic `ChildStream<Sout, Serr>`.
* Rename concrete `ProcessStream` to `ProcessLineStream` _(`ProcessStream` still works as an alias for backward compatibility)_.
* Add `TryFrom<&mut Command> for ChildStream`.
* Update dependency required minimums & avoid semver breakage using `0` versions.

I _think_ this is fully backward compatible, so should be able to publish as `0.1.1`.

## Example
```rust
use tokio_process_stream::{Item, ProcessChunkStream};
use tokio::process::Command;
use tokio_stream::StreamExt;

let mut procstream: ProcessChunkStream = Command::new("/bin/sh")
    .arg("-c")
    .arg(r#"printf "1/2"; sleep 0.1; printf "\r2/2 done\n""#)
    .try_into()?;

while let Some(item) = procstream.next().await {
    println!("{:?}", item);
}
```

Resolves #1 